### PR TITLE
Dialect Class outside of Zephir won't load because of missing CamelCase

### DIFF
--- a/phalcon/db/adapter.zep
+++ b/phalcon/db/adapter.zep
@@ -116,7 +116,7 @@ abstract class Adapter implements AdapterInterface, EventsAwareInterface
 		 * Dialect class can override the default dialect
 		 */
 		if !fetch dialectClass, descriptor["dialectClass"] {
-			let dialectClass = "phalcon\\db\\dialect\\" . this->_dialectType;
+			let dialectClass = "Phalcon\\Db\\Dialect\\" . ucfirst(this->_dialectType);
 		}
 
 		/**


### PR DESCRIPTION
Fixes https://github.com/phalcon/incubator/issues/663

The case-insensitive Class-Instantiation does only work when the Class is also a Zephir one. When it's a PHP Class (like Oracle Dialect now in Incubator) it won't be found if not correctly CamelCased

Hello!

* Type: bug fix | new feature | code quality | documentation
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Thanks

